### PR TITLE
Fixing issues with DNS for new EFS mount targets

### DIFF
--- a/chapter10/efs-backup.yaml
+++ b/chapter10/efs-backup.yaml
@@ -197,7 +197,12 @@ Resources:
             - 'elasticfilesystem:ClientRootAccess'
             - 'elasticfilesystem:ClientWrite'
             - 'elasticfilesystem:ClientMount'
+            - 'elasticfilesystem:DescribeMountTargets'
             Resource: !GetAtt 'FileSystem.Arn'
+          - Effect: Allow
+            Action:
+            - 'ec2:DescribeAvailabilityZones'
+            Resource: '*'
       - PolicyName: ssm
         PolicyDocument:
           Version: '2012-10-17'
@@ -233,10 +238,7 @@ Resources:
 
           # install dependencies
           yum install -y nc amazon-efs-utils
-
-          # wait until EFS file system is available
-          while ! nc -z ${FileSystem}.efs.${AWS::Region}.amazonaws.com 2049; do sleep 10; done
-          sleep 10
+          pip3 install botocore
 
           # copy existing /home to /oldhome
           mkdir /oldhome
@@ -279,10 +281,7 @@ Resources:
 
           # install dependencies
           yum install -y nc amazon-efs-utils
-
-          # wait until EFS file system is available
-          while ! nc -z ${FileSystem}.efs.${AWS::Region}.amazonaws.com 2049; do sleep 10; done
-          sleep 10
+          pip3 install botocore
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab

--- a/chapter10/efs-provisioned.yaml
+++ b/chapter10/efs-provisioned.yaml
@@ -197,7 +197,12 @@ Resources:
             - 'elasticfilesystem:ClientRootAccess'
             - 'elasticfilesystem:ClientWrite'
             - 'elasticfilesystem:ClientMount'
+            - 'elasticfilesystem:DescribeMountTargets'
             Resource: !GetAtt 'FileSystem.Arn'
+          - Effect: Allow
+            Action:
+            - 'ec2:DescribeAvailabilityZones'
+            Resource: '*'
       - PolicyName: ssm
         PolicyDocument:
           Version: '2012-10-17'
@@ -233,10 +238,7 @@ Resources:
 
           # install dependencies
           yum install -y nc amazon-efs-utils
-
-          # wait until EFS file system is available
-          while ! nc -z ${FileSystem}.efs.${AWS::Region}.amazonaws.com 2049; do sleep 10; done
-          sleep 10
+          pip3 install botocore
 
           # copy existing /home to /oldhome
           mkdir /oldhome
@@ -279,10 +281,7 @@ Resources:
 
           # install dependencies
           yum install -y nc amazon-efs-utils
-
-          # wait until EFS file system is available
-          while ! nc -z ${FileSystem}.efs.${AWS::Region}.amazonaws.com 2049; do sleep 10; done
-          sleep 10
+          pip3 install botocore
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab

--- a/chapter10/efs.yaml
+++ b/chapter10/efs.yaml
@@ -197,7 +197,12 @@ Resources:
             - 'elasticfilesystem:ClientRootAccess'
             - 'elasticfilesystem:ClientWrite'
             - 'elasticfilesystem:ClientMount'
+            - 'elasticfilesystem:DescribeMountTargets'
             Resource: !GetAtt 'FileSystem.Arn'
+          - Effect: Allow
+            Action:
+            - 'ec2:DescribeAvailabilityZones'
+            Resource: '*'
       - PolicyName: ssm
         PolicyDocument:
           Version: '2012-10-17'
@@ -233,10 +238,7 @@ Resources:
 
           # install dependencies
           yum install -y nc amazon-efs-utils
-
-          # wait until EFS file system is available
-          while ! nc -z ${FileSystem}.efs.${AWS::Region}.amazonaws.com 2049; do sleep 10; done
-          sleep 10
+          pip3 install botocore
 
           # copy existing /home to /oldhome
           mkdir /oldhome
@@ -279,10 +281,7 @@ Resources:
 
           # install dependencies
           yum install -y nc amazon-efs-utils
-
-          # wait until EFS file system is available
-          while ! nc -z ${FileSystem}.efs.${AWS::Region}.amazonaws.com 2049; do sleep 10; done
-          sleep 10
+          pip3 install botocore
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab


### PR DESCRIPTION
This changes allows the `efs-utils` tool to fetch the IP address of the mount target via API instead of relying on the DNS name, which propagates slowly after initial creation.