### PR TITLE
EFS: Waiting for mount target

### DIFF
--- a/chapter10/efs-backup.yaml
+++ b/chapter10/efs-backup.yaml
@@ -237,12 +237,15 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource EC2InstanceA --region ${AWS::Region}' ERR
 
           # install dependencies
-          yum install -y nc amazon-efs-utils
+          yum install -y amazon-efs-utils
           pip3 install botocore
 
           # copy existing /home to /oldhome
           mkdir /oldhome
           cp -a /home/. /oldhome
+
+          # wait for EFS mount target
+          while ! (echo > /dev/tcp/${FileSystem}.efs.${AWS::Region}.amazonaws.com/2049) >/dev/null 2>&1; do sleep 5; done
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
@@ -280,8 +283,11 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource EC2InstanceB --region ${AWS::Region}' ERR
 
           # install dependencies
-          yum install -y nc amazon-efs-utils
+          yum install -y amazon-efs-utils
           pip3 install botocore
+
+          # wait for EFS mount target
+          while ! (echo > /dev/tcp/${FileSystem}.efs.${AWS::Region}.amazonaws.com/2049) >/dev/null 2>&1; do sleep 5; done
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab

--- a/chapter10/efs-provisioned.yaml
+++ b/chapter10/efs-provisioned.yaml
@@ -238,12 +238,15 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource EC2InstanceA --region ${AWS::Region}' ERR
 
           # install dependencies
-          yum install -y nc amazon-efs-utils
+          yum install -y amazon-efs-utils
           pip3 install botocore
 
           # copy existing /home to /oldhome
           mkdir /oldhome
           cp -a /home/. /oldhome
+
+          # wait for EFS mount target
+          while ! (echo > /dev/tcp/${FileSystem}.efs.${AWS::Region}.amazonaws.com/2049) >/dev/null 2>&1; do sleep 5; done
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
@@ -281,8 +284,11 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource EC2InstanceB --region ${AWS::Region}' ERR
 
           # install dependencies
-          yum install -y nc amazon-efs-utils
+          yum install -y amazon-efs-utils
           pip3 install botocore
+
+          # wait for EFS mount target
+          while ! (echo > /dev/tcp/${FileSystem}.efs.${AWS::Region}.amazonaws.com/2049) >/dev/null 2>&1; do sleep 5; done
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab

--- a/chapter10/efs.yaml
+++ b/chapter10/efs.yaml
@@ -237,12 +237,15 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource EC2InstanceA --region ${AWS::Region}' ERR
 
           # install dependencies
-          yum install -y nc amazon-efs-utils
+          yum install -y amazon-efs-utils
           pip3 install botocore
 
           # copy existing /home to /oldhome
           mkdir /oldhome
           cp -a /home/. /oldhome
+
+          # wait for EFS mount target
+          while ! (echo > /dev/tcp/${FileSystem}.efs.${AWS::Region}.amazonaws.com/2049) >/dev/null 2>&1; do sleep 5; done
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
@@ -280,8 +283,11 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource EC2InstanceB --region ${AWS::Region}' ERR
 
           # install dependencies
-          yum install -y nc amazon-efs-utils
+          yum install -y amazon-efs-utils
           pip3 install botocore
+
+          # wait for EFS mount target
+          while ! (echo > /dev/tcp/${FileSystem}.efs.${AWS::Region}.amazonaws.com/2049) >/dev/null 2>&1; do sleep 5; done
 
           # mount EFS file system
           echo "${FileSystem}:/ /home efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab


### PR DESCRIPTION
Although `efs-utils` with `boto3-core` installed uses the AWS API instead of DNS to connect with the mount target, doing so still fails from time to time. Therefore, I added the wait condition.