### PR TITLE
CH05: Improve HTTP response from Apache

### DIFF
--- a/chapter05/firewall1.yaml
+++ b/chapter05/firewall1.yaml
@@ -88,7 +88,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
-          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
+          echo '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Hello AWS in Action!</title></head><body><p>Hello AWS in Action!</p></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall1.yaml
+++ b/chapter05/firewall1.yaml
@@ -88,6 +88,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
+          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall2.yaml
+++ b/chapter05/firewall2.yaml
@@ -94,7 +94,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
-          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
+          echo '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Hello AWS in Action!</title></head><body><p>Hello AWS in Action!</p></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall2.yaml
+++ b/chapter05/firewall2.yaml
@@ -94,6 +94,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
+          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall3.yaml
+++ b/chapter05/firewall3.yaml
@@ -99,7 +99,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
-          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
+          echo '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Hello AWS in Action!</title></head><body><p>Hello AWS in Action!</p></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall3.yaml
+++ b/chapter05/firewall3.yaml
@@ -99,6 +99,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
+          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall4.yaml
+++ b/chapter05/firewall4.yaml
@@ -104,6 +104,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
+          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall4.yaml
+++ b/chapter05/firewall4.yaml
@@ -104,7 +104,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
-          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
+          echo '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Hello AWS in Action!</title></head><body><p>Hello AWS in Action!</p></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall5.yaml
+++ b/chapter05/firewall5.yaml
@@ -201,6 +201,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Backend --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
+          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Backend --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:

--- a/chapter05/firewall5.yaml
+++ b/chapter05/firewall5.yaml
@@ -201,7 +201,7 @@ Resources:
           trap '/opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource Backend --region ${AWS::Region}' ERR
           yum -y install httpd
           systemctl start httpd
-          echo '<html><title>Hello AWS in Action!</title><body><h1>Hello AWS in Action!</h1></body></html>' > /var/www/html/index.html
+          echo '<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Hello AWS in Action!</title></head><body><p>Hello AWS in Action!</p></body></html>' > /var/www/html/index.html
           /opt/aws/bin/cfn-signal -e 0 --stack ${AWS::StackName} --resource Backend --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:


### PR DESCRIPTION
The default page of Apache returns a `403` which made readers think, that access to the backend server was not allowed. We are now creating our own HTML page which then returns a `200`.