### PR TITLE
Discourse: retry for db:migrate

### DIFF
--- a/chapter11/discourse.yaml
+++ b/chapter11/discourse.yaml
@@ -396,7 +396,7 @@ Resources:
               -e "RUBY_ALLOCATOR=/usr/lib/libjemalloc.so.1" \
               public.ecr.aws/awsinaction/discourse:3rd /sbin/boot
             
-            docker exec discourse /bin/sh -c "cd /var/www/discourse && rake db:migrate"
+            for i in {1..3}; do docker exec discourse /bin/sh -c "cd /var/www/discourse && rake db:migrate" && break; done
             docker restart discourse
           TRY
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}


### PR DESCRIPTION
Unfortunately, db:migrate runs into a timeout/error from time to time causing our tests to fail. I've added a simple retry mechanism and hope this will stabilise things. Nothing but duck tape if you will.